### PR TITLE
Fix Ding et al. link

### DIFF
--- a/vignettes/curatedMSIData.Rmd
+++ b/vignettes/curatedMSIData.Rmd
@@ -87,7 +87,7 @@ ggplot(ssd, aes(y=Total_number_MSI_events+1,x=x)) + geom_point() +
 }
 ```
 
-# [Ding et al. 2018](http://dx.doi.org/10.1038/ncomms15180)
+# [Ding et al. 2018](https://doi.org/10.1016/j.cell.2018.03.033)
 
 The MSIsensor scores from the paper of Ding et al. are provided in
 a simple data.frame.  The gestalt of their Figure 3C can


### PR DESCRIPTION
In the curated MSI data vignette, the link in the Section 3 heading points to Cortes-Ciriano et al., which is also the link for Section 2.
My best guess is it should point to "Perspective on Oncogenic Processes at the End of the Beginning of Cancer Genomics", https://doi.org/10.1016/j.cell.2018.03.033.